### PR TITLE
Improve README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# Hedge_Frontend
+# Hedge System Frontend
+
+This repository contains the React-based frontend for the Hedge System. It provides forms to run PnL simulations and retrieve hedging recommendations.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) and npm. Any recent LTS version (e.g. Node 18) should work.
+
+## Installation
+
+The main application lives inside the `hedge-system-frontend` directory. From the repository root run:
+
+```bash
+cd hedge-system-frontend
+npm install
+```
+
+## Running the application
+
+Inside the `hedge-system-frontend` directory run:
+
+```bash
+npm start
+```
+
+This starts the development server at [http://localhost:3000](http://localhost:3000) and watches for code changes.
+
+## Running tests
+
+While still inside `hedge-system-frontend`, execute:
+
+```bash
+npm test
+```
+
+This launches the interactive test runner provided by Create React App.
+


### PR DESCRIPTION
## Summary
- add project setup and usage instructions in README

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6842192f699c832ea2169c6be1561ff2