### PR TITLE
Add tests for hedge forms

### DIFF
--- a/__mocks__/axios.js
+++ b/__mocks__/axios.js
@@ -1,0 +1,3 @@
+module.exports = {
+  post: jest.fn(),
+};

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,28 @@
+import React from "react";
+import { Container, Navbar, Nav } from "react-bootstrap";
+import RecommendationsForm from "./components/RecommendationsForm";
+import PnLSimulationForm from "./components/PnLSimulationForm";
+
+function App() {
+  return (
+    <Container>
+      <Navbar bg="dark" variant="dark">
+        <Navbar.Brand href="#">Sistema de Hedge Institucional</Navbar.Brand>
+        <Nav className="me-auto">
+          <Nav.Link href="#recommendations">Recomendações</Nav.Link>
+          <Nav.Link href="#simulate">Simulação de PnL</Nav.Link>
+        </Nav>
+      </Navbar>
+      <div id="recommendations">
+        <h2>Recomendações</h2>
+        <RecommendationsForm />
+      </div>
+      <div id="simulate">
+        <h2>Simulação de PnL</h2>
+        <PnLSimulationForm />
+      </div>
+    </Container>
+  );
+}
+
+export default App;

--- a/src/components/PnLSimulationForm.js
+++ b/src/components/PnLSimulationForm.js
@@ -1,0 +1,41 @@
+import React, { useState } from "react";
+import axios from "axios";
+
+function PnLSimulationForm() {
+  const [input, setInput] = useState("");
+  const [response, setResponse] = useState("");
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const result = await axios.post("http://127.0.0.1:8000/pnl/simulate", {
+        data: input,
+      });
+      setResponse(result.data);
+    } catch (error) {
+      console.error("Erro ao enviar simulação:", error);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <label>
+        Dados para Simulação:
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+      </label>
+      <button type="submit">Simular</button>
+      {response && (
+        <div>
+          <h3>Resultado:</h3>
+          <pre>{JSON.stringify(response, null, 2)}</pre>
+        </div>
+      )}
+    </form>
+  );
+}
+
+export default PnLSimulationForm;

--- a/src/components/RecommendationsForm.js
+++ b/src/components/RecommendationsForm.js
@@ -1,0 +1,44 @@
+import React, { useState } from "react";
+import axios from "axios";
+
+function RecommendationsForm() {
+  const [input, setInput] = useState("");
+  const [response, setResponse] = useState("");
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const result = await axios.post(
+        "http://127.0.0.1:8000/hedge/recommendations",
+        {
+          data: input,
+        }
+      );
+      setResponse(result.data);
+    } catch (error) {
+      console.error("Erro ao enviar recomendação:", error);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <label>
+        Dados para Recomendação:
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+      </label>
+      <button type="submit">Enviar</button>
+      {response && (
+        <div>
+          <h3>Resultado:</h3>
+          <pre>{JSON.stringify(response, null, 2)}</pre>
+        </div>
+      )}
+    </form>
+  );
+}
+
+export default RecommendationsForm;

--- a/src/components/__tests__/PnLSimulationForm.test.js
+++ b/src/components/__tests__/PnLSimulationForm.test.js
@@ -1,0 +1,26 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PnLSimulationForm from '../PnLSimulationForm';
+
+jest.mock('axios', () => ({ post: jest.fn() }));
+// eslint-disable-next-line import/first
+import axios from 'axios';
+
+it('envia dados e mostra o resultado', async () => {
+  axios.post.mockResolvedValue({ data: { resultado: 123 } });
+  render(<PnLSimulationForm />);
+
+  fireEvent.change(screen.getByRole('textbox'), { target: { value: 'input' } });
+  fireEvent.click(screen.getByRole('button', { name: /simular/i }));
+
+  await waitFor(() => {
+    expect(axios.post).toHaveBeenCalledWith(
+      'http://127.0.0.1:8000/pnl/simulate',
+      { data: 'input' }
+    );
+  });
+
+  expect(
+    await screen.findByText(/"resultado": 123/)
+  ).toBeInTheDocument();
+});

--- a/src/components/__tests__/RecommendationsForm.test.js
+++ b/src/components/__tests__/RecommendationsForm.test.js
@@ -1,0 +1,26 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import RecommendationsForm from '../RecommendationsForm';
+
+jest.mock('axios', () => ({ post: jest.fn() }));
+// eslint-disable-next-line import/first
+import axios from 'axios';
+
+it('envia dados e exibe a resposta', async () => {
+  axios.post.mockResolvedValue({ data: { ok: true } });
+  render(<RecommendationsForm />);
+
+  fireEvent.change(screen.getByRole('textbox'), { target: { value: 'teste' } });
+  fireEvent.click(screen.getByRole('button', { name: /enviar/i }));
+
+  await waitFor(() => {
+    expect(axios.post).toHaveBeenCalledWith(
+      'http://127.0.0.1:8000/hedge/recommendations',
+      { data: 'teste' }
+    );
+  });
+
+  expect(
+    await screen.findByText(/"ok": true/)
+  ).toBeInTheDocument();
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,1 @@
+// placeholder

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- create React components directory
- add RecommendationsForm and PnLSimulationForm components
- add jest setup file
- add unit tests for both forms

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6842194598dc832e9147127e9c03df41